### PR TITLE
Fix async search params in public courses page

### DIFF
--- a/app/s/[subdomain]/(public)/courses/page.tsx
+++ b/app/s/[subdomain]/(public)/courses/page.tsx
@@ -15,9 +15,15 @@ export const dynamic = 'force-dynamic';
 export default async function PublicCoursesroute({
   searchParams,
 }: {
-  searchParams?: Promise<{ q?: string; category?: string }>;
+  searchParams?: Promise<URLSearchParams>;
 }) {
-  const resolvedSearchParams = await searchParams;
+  const params = await searchParams;
+
+  // Extract filters from URLSearchParams (handling undefined values gracefully)
+  const filters = {
+    q: params?.get('q') || undefined,
+    category: params?.get('category') || undefined,
+  } as const;
 
   return (
     <div className='from-background via-secondary/10 to-background min-h-screen bg-gradient-to-b'>
@@ -66,7 +72,7 @@ export default async function PublicCoursesroute({
           </div>
 
           <Suspense fallback={<LoadingSkeletonLayout />}>
-            <RenderCourses searchParams={resolvedSearchParams} />
+            <RenderCourses filters={filters} />
           </Suspense>
         </div>
       </section>
@@ -75,14 +81,11 @@ export default async function PublicCoursesroute({
 }
 
 async function RenderCourses({
-  searchParams,
+  filters,
 }: {
-  searchParams?: { q?: string; category?: string };
+  filters: { q?: string; category?: string };
 }) {
-  const courses = await getAllCourses({
-    q: searchParams?.q,
-    category: searchParams?.category,
-  });
+  const courses = await getAllCourses(filters);
 
   return <CourseSearchWrapper courses={courses} />;
 }


### PR DESCRIPTION
Update `searchParams` handling in `PublicCoursesroute` to correctly await `URLSearchParams` in Next.js 15.

This fixes the `searchParams should be awaited before using its properties` error, which occurs because Next.js 15 now passes `searchParams` as a Promise to Server Components. The change ensures `searchParams` is awaited before accessing its properties.

---
<a href="https://cursor.com/background-agent?bcId=bc-84797e3b-e444-4fa1-8fa0-f13b427d332f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-84797e3b-e444-4fa1-8fa0-f13b427d332f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

